### PR TITLE
61 - fix prod config for API gateway

### DIFF
--- a/config/local.yaml
+++ b/config/local.yaml
@@ -1,4 +1,5 @@
 server:
+  # you can only hit this from within localhost
   host: 127.0.0.1
   port: 3555
 # You'll need your own instance hosting cardano-graphql

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,6 +1,7 @@
 server:
-  host: 127.0.0.1
+  # leave host blank or server will only accept calls from localhost
+  host: 
   port: 3555
 cardano-graphql:
-  host: 127.0.0.1
+  host: http://127.0.0.1
   port: 3100


### PR DESCRIPTION
- Golang will not allow incoming connections when IP is set explicitly to localhost

https://trello.com/c/AZKctmmf

@RektangularStudios/rektangularstudios 